### PR TITLE
Remove correspondence-language in favor of core-attribute

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: 'Lint and test'
 
 on:
-  # The nightly obuild allows us to notice if changes to the core
+  # The nightly build allows us to notice if changes to the core
   # break the wagon.
   schedule:
   - cron:  '38 3 * * *'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hitobito Changelog
 
+## unreleased
+
+* Wechsel von Korrespondenzsprache als Wagon-Attribut zum Core-Attribut Sprache (hitobito#2620)
+
 ## Version 1.11
 
 * completely new generic structure, more in line with what organizations actually look like today.

--- a/app/controllers/generic/people_controller.rb
+++ b/app/controllers/generic/people_controller.rb
@@ -15,7 +15,6 @@ module Generic::PeopleController
     self.permitted_attrs += [
       :additional_languages,
       :advertising,
-      :correspondence_language,
       :nationality,
       :title
     ]

--- a/app/helpers/people_generic_helper.rb
+++ b/app/helpers/people_generic_helper.rb
@@ -6,10 +6,6 @@
 #  https://github.com/hitobito/hitobito_generic.
 
 module PeopleGenericHelper
-  def format_person_correspondence_language(person)
-    person.correspondence_language_label
-  end
-
   def format_person_advertising(person)
     person.advertising_label
   end

--- a/app/models/generic/person.rb
+++ b/app/models/generic/person.rb
@@ -9,14 +9,9 @@ module Generic::Person
   extend ActiveSupport::Concern
 
   included do
-    Person::PUBLIC_ATTRS << :title << :correspondence_language <<
-                            :additional_languages << :advertising
+    Person::PUBLIC_ATTRS << :title << :additional_languages << :advertising
 
-    CORRESPONDENCE_LANGUAGES = %w(de fr it en).freeze
     ADVERTISINGS = %w(none by_members by_anyone).freeze
-
-    i18n_enum :correspondence_language, CORRESPONDENCE_LANGUAGES
-    i18n_setter :correspondence_language, CORRESPONDENCE_LANGUAGES
 
     i18n_enum :advertising, ADVERTISINGS
     i18n_setter :advertising, ADVERTISINGS

--- a/app/views/people/_details_generic.html.haml
+++ b/app/views/people/_details_generic.html.haml
@@ -1,2 +1,2 @@
-= render_attrs(entry, :title, :nationality, :correspondence_language, :additional_languages, :advertising)
+= render_attrs(entry, :title, :nationality, :additional_languages, :advertising)
 

--- a/app/views/people/_fields_generic.html.haml
+++ b/app/views/people/_fields_generic.html.haml
@@ -15,10 +15,6 @@
   = f.labeled_input_field :additional_languages,
                           data: { provide: :typeahead, source: @languages }
 
-  = f.labeled(:correspondence_language) do
-    - Person::CORRESPONDENCE_LANGUAGES.each do |key|
-      = f.inline_radio_button(:correspondence_language, key, entry.correspondence_language_label(key))
-
   = f.labeled(:advertising) do
     - Person::ADVERTISINGS.each do |key|
       = f.inline_radio_button(:advertising, key, entry.advertising_label(key))

--- a/config/locales/models.generic.de.yml
+++ b/config/locales/models.generic.de.yml
@@ -58,12 +58,5 @@ de:
           none: Nein
           by_members: Ja, durch Mitglieder
           by_anyone: Ja, durch Mitglieder und Dritte
-        correspondence_language: Korrespondenzsprache
-        correspondence_languages:
-          _nil: Nicht gesetzt
-          de: Deutsch
-          fr: Französisch
-          it: Italienisch
-          en: Englisch
         nationality: Nationalität
         title: Titel

--- a/config/locales/models.generic.en.yml
+++ b/config/locales/models.generic.en.yml
@@ -50,12 +50,5 @@ en:
           none: none
           by_members: yes, by members
           by_anyone: yes, by anyone
-        correspondence_language: correspondence language
-        correspondence_languages:
-          _nil: not set
-          de: german
-          fr: french
-          it: italian
-          en: english
         nationality: nationality
         title: title

--- a/config/locales/models.generic.fr.yml
+++ b/config/locales/models.generic.fr.yml
@@ -57,12 +57,5 @@ fr:
           none: Non
           by_members: Oui, par membres
           by_anyone: Oui, par membres et autres
-        correspondence_language: Langue de correspondance
-        correspondence_languages:
-          _nil: Non défini
-          de: Allemand
-          fr: Français
-          it: Italien
-          en: Anglais
         nationality: Nationalité
         title: Titre

--- a/db/migrate/20240528203329_drop_correspondence_language_from_people.rb
+++ b/db/migrate/20240528203329_drop_correspondence_language_from_people.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024-2024, Puzzle ITC. This file is part of
+#  hitobito_generic and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_generic.
+
+class DropCorrespondenceLanguageFromPeople < ActiveRecord::Migration[6.1]
+  def change
+    reversible do |dir|
+      dir.up { execute("UPDATE people SET language = IFNULL(correspondence_language, 'de')") }
+      dir.down { execute("UPDATE people SET correspondence_language = language") }
+    end
+
+    remove_column(:people, :correspondence_language, :string)
+  end
+end


### PR DESCRIPTION
While hitobito/hitobito#2633 restrict the language-filter to wagons that use the new field, this PR switches from the correspondence-language to the core-attribute.

Fixes hitobito/hitobito#2620